### PR TITLE
fix(manga): stop error cascade when deferred reply is gone

### DIFF
--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -53,15 +53,19 @@ export default {
             console.error(error);
             const locale = await resolveLocale(interaction).catch(() => "en" as const);
             const errorMsg = t(locale, "common.error");
-            if (!interaction.replied && !interaction.deferred) {
-                await interaction.reply({
-                    content: errorMsg,
-                    flags: MessageFlags.Ephemeral,
-                });
-            } else {
-                await interaction.editReply({
-                    content: errorMsg,
-                });
+            try {
+                if (!interaction.replied && !interaction.deferred) {
+                    await interaction.reply({
+                        content: errorMsg,
+                        flags: MessageFlags.Ephemeral,
+                    });
+                } else {
+                    await interaction.editReply({
+                        content: errorMsg,
+                    });
+                }
+            } catch {
+                // Interaction token expired or reply message was deleted — nothing else we can do.
             }
         }
 

--- a/src/util/manga/handler.ts
+++ b/src/util/manga/handler.ts
@@ -183,7 +183,9 @@ export function mangaCommand(source: MangaSource) {
                         : `${SERVER_HD}${source.apiPath}/get?book=${interaction.options.getInteger("id", true)}`;
 
                 const response = await axios.get(apiUrl);
-                if (!response.data?.data) return;
+                if (!response.data?.data) {
+                    throw new Error("Upstream response missing data payload");
+                }
 
                 const result = response.data.data;
 
@@ -204,7 +206,11 @@ export function mangaCommand(source: MangaSource) {
 
                 await interaction.editReply({ embeds: [embed], components: [row] });
                 await wait(BUTTON_REMOVE_DELAY);
-                await interaction.editReply({ components: [] });
+                try {
+                    await interaction.editReply({ components: [] });
+                } catch {
+                    // Best-effort cleanup — message may have been deleted during the wait.
+                }
             } catch (error) {
                 log(`[manga:${source.name}] ${error instanceof Error ? error.message : "Unknown error"}`, "error");
                 try {
@@ -215,10 +221,14 @@ export function mangaCommand(source: MangaSource) {
                         "error"
                     );
                 }
-                await interaction.editReply({
-                    content: t(locale, "manga.load_failed"),
-                    components: [buildErrorRow(locale)],
-                });
+                try {
+                    await interaction.editReply({
+                        content: t(locale, "manga.load_failed"),
+                        components: [buildErrorRow(locale)],
+                    });
+                } catch {
+                    // Original interaction expired or message was deleted — nothing to edit.
+                }
             }
         },
     };


### PR DESCRIPTION
## Summary
- Prevent a single `10008 Unknown Message` / `10062 Unknown interaction` from producing three cascading `DiscordAPIError` stack traces per manga command incident.
- Wrap the post-wait button cleanup, the catch-block error `editReply`, and the generic `interactionCreate` fallback in try/catch.
- Replace the silent early `return` on malformed upstream payloads with a thrown error so the user sees "failed to load" + gets the star refunded instead of being stuck on "thinking…".

## Why
Production `pm2` logs showed recurring triple-error bursts on `/3hentai`, `/asmhentai`, `/hentaifox`, `/nhentai`. Tracing the stacks:
- **10008 cascade** — user deletes the bot's reply during the 20 s `BUTTON_REMOVE_DELAY` wait. The post-wait `editReply({ components: [] })` throws, enters the catch block whose own `editReply` throws, propagates to `interactionCreate` whose fallback `editReply` throws.
- **10062 cascade** — `deferReply()` itself fails (3 s budget exceeded by star-charge path during Redis/Mongo latency spikes). The catch-block `editReply` then throws `InteractionNotReplied`, which propagates to `interactionCreate` where `reply()` hits the dead token.

## Test plan
- [ ] Run a manga command, delete the bot's reply within 20 seconds → verify a single warning is logged and no `DiscordAPIError` stack trace appears.
- [ ] Force an upstream 400 from `SERVER_HD` → verify the error embed shows and the star is refunded.
- [ ] Simulate a malformed upstream response (`{}`) → verify the user sees "failed to load" instead of eternal "thinking…" and star is refunded.
- [ ] Regression: successful `/nhentai read <id>` still works end-to-end (embed + buttons + button removal after 20 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)